### PR TITLE
fix new member password not correct error

### DIFF
--- a/code/extensions/EmailVerificationMemberExtension.php
+++ b/code/extensions/EmailVerificationMemberExtension.php
@@ -62,7 +62,7 @@ class EmailVerificationMemberExtension extends DataExtension {
         }
 
         if (!$this->owner->Verified && !$this->owner->VerificationEmailSent) {
-            $this->owner->sendVerificationEmail();
+            $this->owner->VerificationEmailSent = $this->owner->sendVerificationEmail();
         }
     }
 
@@ -100,8 +100,8 @@ class EmailVerificationMemberExtension extends DataExtension {
         $email_to_recipient->setTemplate('VerificationEmail');
         $email_to_recipient->populateTemplate($email_template_data);
 
-        $this->owner->VerificationEmailSent = $email_to_recipient->send();
-        $this->owner->write();
+        return $email_to_recipient->send();
+        
     }
 
     /**


### PR DESCRIPTION
Due to sendVerificationEmail() runs in onBeforeWrite(), before the write() function actually done, the new member object won't have an ID.
And this sendVerificationEmail() also calls write() after the email has been sent, the following process will happen.

In the onBeforeWrite() function in Member class,
it encrypts the password and save the encrypted password in password,
the second time in onBeforeWrite(), it encrypts the encrypted passowrd and save in password field.

This will cause the actual password won't be the one a user typed in or set in member object before written into database.
