### PR TITLE
prevent xss injection

### DIFF
--- a/code/extensions/EmailVerificationSecurityExtension.php
+++ b/code/extensions/EmailVerificationSecurityExtension.php
@@ -82,7 +82,7 @@ class EmailVerificationSecurityExtension extends Extension {
      */
     public function VerifyEmailForm() {
         $email_field_label = singleton('Member')->fieldLabel(Member::config()->unique_identifier_field);
-        $email_field = TextField::create('Email', $email_field_label, null, null, $this)->setAttribute('autofocus', 'autofocus');
+        $email_field = EmailField::create('Email', $email_field_label, null, null, $this)->setAttribute('autofocus', 'autofocus');
 
         $fields = FieldList::create(
             $email_field
@@ -112,9 +112,9 @@ class EmailVerificationSecurityExtension extends Extension {
     public function submitVerifyEmailForm($data) {
         $controller = Controller::curr();
         $email = isset($data['Email']) ? $data['Email'] : false;
-
-        if(!$email) {
-            return $controller->redirect('/Security/login');
+        $email = Convert::raw2sql($email);
+        if( !($email && Email::is_valid_address($email)) ) {
+            return $controller->redirect('/Security/verify-email');
         }
 
         $member = Member::get()->filter(array(


### PR DESCRIPTION
The email field is changed to only accept email addresses. In the event that someone slips through a non-email value, the action also checks  for a valid address. Failure just reloads the page.